### PR TITLE
Improved indentation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the "rgbds-z80" extension will be documented in this file.
 
+## [3.2.1] - 2023-06-21
+### Added
+ - Support for indented documentation.
+ - Support for indented macro definitions.
+
 ## [3.2.0] - 2023-04-30
 ### Added
 - Support for the `fmod` function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rgbds-z80",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "rgbds-z80",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "dependencies": {
                 "xml-js": "~1.6.11"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rgbds-z80",
     "displayName": "RGBDS Z80",
     "description": "Language service for RGBDS GB Z80.",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "publisher": "donaldhays",
     "engines": {
         "vscode": "^1.22.0"

--- a/src/symbolDocumenter.ts
+++ b/src/symbolDocumenter.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { syntaxInfo } from './syntaxInfo';
 
-const commentLineRegex = /^;\s*(.*)$/
+const commentLineRegex = /^\s*;\s*(.*)$/
 const endCommentRegex = /^[^;]+;\s*(.*)$/
 
 const singleLineBlockCommentRegex = /^.*\/\*+\s*(.*?)\s*\*\/.*$/
@@ -20,7 +20,7 @@ const labelDefinitionRegex = /^[\s]*((([a-zA-Z_][a-zA-Z_0-9]*)?\.)?[a-zA-Z_][a-z
 const defineExpressionRegex = /^[\s]*(?:def[\s]*)?([a-zA-Z_][a-zA-Z_0-9]*)[\s]+(equ|equs|set|=)[\s]+.*$/i
 const instructionRegex = new RegExp(`^(${syntaxInfo.instructions.join("|")})\\b`, "i");
 const keywordRegex = new RegExp(`^(${syntaxInfo.preprocessorKeywords.join("|")})\\b`, "i");
-const macroDefinitionRegex = /^macro[\s]+([a-zA-Z_][a-zA-Z_0-9]*).*$/i
+const macroDefinitionRegex = /^\s*macro[\s]+([A-Z_]\w*).*$/i
 
 class ScopeDescriptor {
   constructor(public start: vscode.Position, public end?: vscode.Position) { }


### PR DESCRIPTION
Hi, I have been using this extension for a few years now, and I like it a lot! It makes coding in assembly a much less tedious process, and being able to jump to a symbol by ctrl-clicking it is just wonderful to have.
However, I have a few gripes with it that I would like to see remedied or fixed entirely, so I am going to make a series of pull requests, this one being the first!

This is the one that frustrates me the most:
Better indentation support. I like to indent my code like you would in a traditional programming language. RGBDS fully supports this, but this extension gives me a lot of pushback, unfortunately.

**Problems this aims to fix:**
* **Symbol documentation** is currently not supported, if the documentation is indented. I do not see why it shouldn't be possible to have indented documentation for indented labels, so I have changed the regular expression used for matching comments, to include possible whitespace at the beginning of the line.
* **Indented macro definitions** were not supported either. Same problem as the above, RGBDS supports it, so why not.
* **The auto-decrease-indent pattern.** I get what this is supposed to do, but this should either be opt-in behavior, or disabled entirely, as it does not work for indented codestyles. Whenever I create a new label, be it local or not, the definition always jumps back to the start of the line. This forces me to manually re-indent it, which is extremely frustrating. Therefore, I have removed this.