### PR TITLE
Update label definition regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to the "rgbds-z80" extension will be documented in this file.
 
+## [3.3.0] - 2023-06-22
+### Removed
+ - Support for colon-less label declarations.
+
+### Fixed
+ - Invoking a macro would mistakingly be seen as re-declaring it.
+
 ## [3.2.1] - 2023-06-21
 ### Added
  - Support for indented documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rgbds-z80",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "rgbds-z80",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "dependencies": {
                 "xml-js": "~1.6.11"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rgbds-z80",
     "displayName": "RGBDS Z80",
     "description": "Language service for RGBDS GB Z80.",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "publisher": "donaldhays",
     "engines": {
         "vscode": "^1.22.0"

--- a/src/symbolDocumenter.ts
+++ b/src/symbolDocumenter.ts
@@ -16,7 +16,7 @@ const blockCommentEndRegex = /^(.*?)\s*\*\/.*$/
 
 const includeLineRegex = /^include[\s]+"([^"]+)".*$/i
 const spacerRegex = /^\s*(.)\1{3,}\s*$/
-const labelDefinitionRegex = /^[\s]*((([a-zA-Z_][a-zA-Z_0-9]*)?\.)?[a-zA-Z_][a-zA-Z_0-9]*[:]{0,2}).*$/
+const labelDefinitionRegex = /^\s*((?:[A-Z_]\w+)?(?:(?:\.[A-Z_]\w+:{0,2})|(?:[A-Z_]\w+:{1,2})))/i
 const defineExpressionRegex = /^[\s]*(?:def[\s]*)?([a-zA-Z_][a-zA-Z_0-9]*)[\s]+(equ|equs|set|=)[\s]+.*$/i
 const instructionRegex = new RegExp(`^(${syntaxInfo.instructions.join("|")})\\b`, "i");
 const keywordRegex = new RegExp(`^(${syntaxInfo.preprocessorKeywords.join("|")})\\b`, "i");

--- a/src/symbolDocumenter.ts
+++ b/src/symbolDocumenter.ts
@@ -16,7 +16,7 @@ const blockCommentEndRegex = /^(.*?)\s*\*\/.*$/
 
 const includeLineRegex = /^include[\s]+"([^"]+)".*$/i
 const spacerRegex = /^\s*(.)\1{3,}\s*$/
-const labelDefinitionRegex = /^\s*((?:[A-Z_]\w+)?(?:(?:\.[A-Z_]\w+:{0,2})|(?:[A-Z_]\w+:{1,2})))/i
+const labelDefinitionRegex = /^\s*((?:[A-Z_]\w*)?(?:(?:\.[A-Z_]\w*:{0,2})|(?:[A-Z_]\w*:{1,2})))/i
 const defineExpressionRegex = /^[\s]*(?:def[\s]*)?([a-zA-Z_][a-zA-Z_0-9]*)[\s]+(equ|equs|set|=)[\s]+.*$/i
 const instructionRegex = new RegExp(`^(${syntaxInfo.instructions.join("|")})\\b`, "i");
 const keywordRegex = new RegExp(`^(${syntaxInfo.preprocessorKeywords.join("|")})\\b`, "i");


### PR DESCRIPTION
This removes support for global labels without any colons at the end. I feel this is justified, as that style of label was removed from RGBDS in [v0.5.0](https://github.com/gbdev/rgbds/releases/tag/v0.5.0). That version released over 2 years ago, and the chances of anyone still using RGBDS v0.4.x at this point, are probably slim.

## Example
Here is an example of what label definitions are/aren't supported:

```asm
label          ;Not allowed, could overlap a macro invocation
label:         ;Allowed
label::        ;Allowed
.label         ;Allowed
.label:        ;Allowed
.label::       ;Allowed
label.local    ;Allowed
label.local:   ;Allowed
label.local::  ;Allowed
.label.local   ;Not allowed, sub-label within sub-label
.label.local:  ;Not allowed, sub-label within sub-label
.label.local:: ;Not allowed, sub-label within sub-label
```

## Benefits of this change
* This fixes macro documentation. Previously, when invoking a macro, the documentation provider would see the invokation as a label definition. This caused the documentation from the macro to be erased, and replaced with the documentation of the invocation of the macro. In the example below, the documentation provider would return `Invoke macro` for `name`, as it thinks it has been redeclared as a label:
```asm
; Loads a value into B.
MACRO name
    ld b, \1
ENDM

; Invoke macro
name 8
```

## Further considerations
I have considered doing a minor refactor of the documentation provider. The logic for macros and constants could be made simpler, as neither can be local or exported, and don't exactly belong to a scope either. That would free all of those terms for labels specifically, which opens up the ability to specialize them for that purpose.