### PR TITLE
Jump to included files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to the "rgbds-z80" extension will be documented in this file.
 
-## [3.3.0] - 2023-06-22
+## [3.3.0] - 2023-06-24
+### Added
+ - Suggested included files will now use forward slash as directory separator on Windows.
+ - The ability to jump to included files by ctrl+clicking the include statement.
+
 ### Removed
  - Support for colon-less label declarations.
 

--- a/src/completionProposer.ts
+++ b/src/completionProposer.ts
@@ -358,9 +358,9 @@ export class ASMCompletionProposer implements vscode.CompletionItemProvider {
           }
           
           if (shouldIncludeQuotes) {
-            output.push(new vscode.CompletionItem(`"${relative}"`, vscode.CompletionItemKind.File));
+            output.push(new vscode.CompletionItem(`"${relative.replace("\\", "/")}"`, vscode.CompletionItemKind.File));
           } else {
-            output.push(new vscode.CompletionItem(relative, vscode.CompletionItemKind.File));
+            output.push(new vscode.CompletionItem(relative.replace("\\", "/"), vscode.CompletionItemKind.File));
           }
           return;
         }

--- a/src/documentLinkProvider.ts
+++ b/src/documentLinkProvider.ts
@@ -1,0 +1,33 @@
+"use strict";
+
+import * as vscode from 'vscode';
+import { ASMSymbolDocumenter } from './symbolDocumenter';
+
+export class ASMDocumentLinkProvider implements vscode.DocumentLinkProvider {
+  constructor(public symbolDocumenter: ASMSymbolDocumenter) {
+    
+  }
+
+  provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
+    const filename = document.uri.fsPath;
+    const table = this.symbolDocumenter.files[filename];
+    if (table == null) {
+        return undefined;
+    }
+    
+    let output: vscode.DocumentLink[] = [];
+    for (let i = 0; i < table.includedFiles.length; i++) {
+        const include = table.includedFiles[i];
+        if (include.fsPath) {
+            let link = new vscode.DocumentLink(include.range, vscode.Uri.file(include.fsPath));
+            output.push(link);
+        }
+    }
+
+    return output;
+  }
+
+  resolveDocumentLink(link: vscode.DocumentLink, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink> {
+    return null;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { ASMCompletionProposer } from './completionProposer';
 import { ASMDefinitionProvider } from './definitionProvider';
 import { ASMDocumentSymbolProvider } from './documentSymbolProvider';
 import { ASMWorkspaceSymbolProvider } from './workspaceSymbolProvider';
+import { ASMDocumentLinkProvider } from './documentLinkProvider';
 
 export function activate(context: vscode.ExtensionContext) {
   const symbolDocumenter = new ASMSymbolDocumenter();
@@ -21,6 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.languages.registerDefinitionProvider({ language: "gbz80", scheme: "file" }, new ASMDefinitionProvider(symbolDocumenter)));
   context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider({ language: "gbz80", scheme: "file" }, new ASMDocumentSymbolProvider(symbolDocumenter)));
   context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new ASMWorkspaceSymbolProvider(symbolDocumenter)));
+  context.subscriptions.push(vscode.languages.registerDocumentLinkProvider({ language: "gbz80", scheme: "file" }, new ASMDocumentLinkProvider(symbolDocumenter)));
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
This replaces any backslashes with forward slashes in proposed completions for included files.

## Additions:
* Adds the ability to ctrl+click on a file link in an include statement, and be brought straight to that file. If a file cannot be found in the include directories, no link shows up. This is just pure convenience, and is something I have personally been missing.

## Fixes:
* Completion proposals for included files would use backslashes for directory separators on Windows. This is annoying, as when that gets pasted into the file, you have to manually either escape the backslashes with another backslash, or correct them to forward slashes. I opted to just replace them with forward slashes, to maintain compatibility with other OS'es.