### PR TITLE
Add highlighting and completion support for the ldi and ldd instructions

### DIFF
--- a/formatting.md
+++ b/formatting.md
@@ -105,7 +105,7 @@ routine::
 
 ##### `language.instruction`
 
-`adc, add, and, bit, call, ccf, cp, cpl, daa, dec, di, ei, halt, inc, jp, jr, ld, ldh, nop, or, pop, push, res, ret, reti, rl, rla, rlc, rlca, rr, rra, rrc, rrca, rst, sbc, scf, set, sla, sra, srl, stop, sub, swap, xor`
+`adc, add, and, bit, call, ccf, cp, cpl, daa, dec, di, ei, halt, inc, jp, jr, ld, ldh, ldi, ldd, nop, or, pop, push, res, ret, reti, rl, rla, rlc, rlca, rr, rra, rrc, rrca, rst, sbc, scf, set, sla, sra, srl, stop, sub, swap, xor`
 
 ##### `language.hex`
 

--- a/instructions.json
+++ b/instructions.json
@@ -507,9 +507,23 @@
       "flags" : {}
     },
     {
+      "name" : "ldi [hl], a",
+      "description" : "[`hl`] = `a`, `hl` += 1",
+      "cycles" : 2,
+      "bytes" : 1,
+      "flags" : {}
+    },
+    {
       "name" : "ld [hl-], a",
       "description" : "[`hl`] = `a`, `hl` -= 1",
       "aliasHLD" : true,
+      "cycles" : 2,
+      "bytes" : 1,
+      "flags" : {}
+    },
+    {
+      "name" : "ldd [hl], a",
+      "description" : "[`hl`] = `a`, `hl` -= 1",
       "cycles" : 2,
       "bytes" : 1,
       "flags" : {}
@@ -523,9 +537,23 @@
       "flags" : {}
     },
     {
+      "name" : "ldi a, [hl]",
+      "description" : "`a` = [`hl`], `hl` += 1",
+      "cycles" : 2,
+      "bytes" : 1,
+      "flags" : {}
+    },
+    {
       "name" : "ld a, [hl-]",
       "description" : "`a` = [`hl`], `hl` -= 1",
       "aliasHLD" : true,
+      "cycles" : 2,
+      "bytes" : 1,
+      "flags" : {}
+    },
+    {
+      "name" : "ldd a, [hl]",
+      "description" : "`a` = [`hl`], `hl` -= 1",
       "cycles" : 2,
       "bytes" : 1,
       "flags" : {}

--- a/syntaxes/rgbds-asm.tmLanguage
+++ b/syntaxes/rgbds-asm.tmLanguage
@@ -102,7 +102,7 @@
 			<key>name</key>
 			<string>keyword.other.opcode.gbz80</string>
 			<key>match</key>
-			<string>\b(?i:adc|add|and|bit|call|ccf|cp|cpl|daa|dec|di|ei|halt|inc|jp|jr|ld|ldh|nop|or|pop|push|res|ret|reti|rl|rla|rlc|rlca|rr|rra|rrc|rrca|rst|sbc|scf|sla|sra|srl|stop|sub|swap|xor)\b</string>
+			<string>\b(?i:adc|add|and|bit|call|ccf|cp|cpl|daa|dec|di|ei|halt|inc|jp|jr|ld|ldh|ldi|ldd|nop|or|pop|push|res|ret|reti|rl|rla|rlc|rlca|rr|rra|rrc|rrca|rst|sbc|scf|sla|sra|srl|stop|sub|swap|xor)\b</string>
 		</dict>
 		<dict>
 			<key>name</key>


### PR DESCRIPTION
Add the ldi and ldd instructions to [syntaxes/rgbds-asm.tmLanguage](https://github.com/DonaldHays/rgbds-vscode/compare/master...RubenZwietering:rgbds-vscode:support-ldi-ldd?expand=1#diff-a67bdc5360a087c776520536a9ff57e9a59145b90003b7f44e38ff3547fae401), [instructions.json](https://github.com/DonaldHays/rgbds-vscode/compare/master...RubenZwietering:rgbds-vscode:support-ldi-ldd?expand=1#diff-d4a451ad2863e5577b7cc521ab817f447f4a7c53c11bf6281e7fc34511f35f2a) and [formatting.md](https://github.com/DonaldHays/rgbds-vscode/compare/master...RubenZwietering:rgbds-vscode:support-ldi-ldd?expand=1#diff-01de2aa6ee4101ffd3b87cb7a15c99d1d745539fc94e6f4c361f461c46c5b5eb) for highlighting and completion support.
These instructions are aliases for the ld instruction with [hli/hl+] and [hld/hl-]. Rgbds documentation on [LD [HLI],A](https://rgbds.gbdev.io/docs/master/gbz80.7#LD__HLI_,A) and [LD [HLD],A](https://rgbds.gbdev.io/docs/master/gbz80.7#LD__HLD_,A)